### PR TITLE
Revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,16 +6,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>Course Chat</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
         <header>
-            <div class="header-info">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
                 <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -67,29 +67,13 @@ body {
 /* Header - Visible with Theme Toggle */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -1036,12 +1020,6 @@ details[open] .suggested-header::before {
     transform: rotate(0deg) scale(1);
 }
 
-/* Header info section */
-.header-info {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-}
 
 /* Mobile adjustments for theme toggle */
 @media (max-width: 768px) {


### PR DESCRIPTION
Fixes #1

This PR reverts the header to the older version as requested:
- Removes "Course Materials Assistant" header title
- Removes subheader text about asking questions
- Removes horizontal row below the subheader
- Preserves theme toggle functionality

Generated with [Claude Code](https://claude.ai/code)